### PR TITLE
Added release-drafter to the master workflow

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,34 @@
+version-template: $MAJOR.$MINOR.$PATCH.RELEASE
+name-template: v$RESOLVED_VERSION
+tag-template: $RESOLVED_VERSION
+categories:
+  - title: ⭐ New Features
+    labels:
+      - enhancement
+  - title: 🐞 Bug Fixes
+    labels:
+      - bug
+  - title: 📔 Documentation
+    labels:
+      - documentation
+  - title: 🔨 Maintenance
+    labels:
+      - dependency-upgrade
+      - internal
+      - tests
+version-resolver:
+  major:
+    labels:
+      - breaking-change
+  minor:
+    labels:
+      - enhancement
+  patch:
+    labels:
+      - documentation
+      - bug
+      - dependency-upgrade
+      - internal
+      - tests
+  default: patch
+template: |

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,9 +1,13 @@
-name: Build master branch
+name: Build master-branch
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
 
 jobs:
   build:
+    name: Build
     runs-on: ubuntu-latest
 
     steps:
@@ -17,3 +21,12 @@ jobs:
 
       - name: Build with Maven
         run: mvn -B verify
+
+  update_release_draft:
+    name: Update release draft
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,19 @@
+name: Build Pull Request
+
+on: [pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Set up JDK 9
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.9
+
+      - name: Build with Maven
+        run: mvn -B verify


### PR DESCRIPTION
release-drafter enables the GHA workflow to automatically generate a release draft with release notes whenever pull requests are merged into `master`.