### PR TITLE
Add YAML Lint to the GHA workflows

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -22,9 +22,20 @@ jobs:
       - name: Build with Maven
         run: mvn -B verify
 
+  yaml_lint:
+    name: YAML lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Validate YAML files
+        uses: ibiqlik/action-yamllint@v1
+
   update_release_draft:
     name: Update release draft
     runs-on: ubuntu-latest
+    needs: [build, yaml_lint]
 
     steps:
       - uses: release-drafter/release-drafter@v5

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -4,6 +4,7 @@ on: [pull_request]
 
 jobs:
   build:
+    name: Build
     runs-on: ubuntu-latest
 
     steps:
@@ -17,3 +18,13 @@ jobs:
 
       - name: Build with Maven
         run: mvn -B verify
+
+  yaml_lint:
+    name: YAML lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Validate YAML files
+        uses: ibiqlik/action-yamllint@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,21 @@ on:
     types: [published]
 
 jobs:
-  build:
+
+  yaml_lint:
+    name: YAML lint
     runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Validate YAML files
+        uses: ibiqlik/action-yamllint@v1
+
+  build:
+    name: Deploy
+    runs-on: ubuntu-latest
+    needs: [yaml_lint]
 
     steps:
       - name: Checkout sources

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,6 @@
+extends: default
+
+rules:
+  document-start: disable
+  truthy:
+    check-keys: false


### PR DESCRIPTION
GHA configuration files are often written in YAML, which means it makes sense to validate these files as part of the workflows.