### PR TITLE
Updated the release workflow to set env variables differently

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Extract release version
-        run: echo ::set-env name=RELEASE_VERSION::${GITHUB_REF#refs/*/}
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
 
       - name: Set up JDK 9 and settings.xml
         uses: actions/setup-java@v1


### PR DESCRIPTION
GitHub is changing how env variables should be set in GHA workflows: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/