### PR TITLE
Remove extra curly brace from the JavaDoc on WireMockStubsConfiguration.resetBeforeEachTest

### DIFF
--- a/src/main/java/com/thomaskasene/wiremock/junit/WireMockStubsConfiguration.java
+++ b/src/main/java/com/thomaskasene/wiremock/junit/WireMockStubsConfiguration.java
@@ -65,7 +65,7 @@ public interface WireMockStubsConfiguration {
      * This method is run once before each test, and should generally be used to clear the WireMock context and any
      * {@link WireMockStub} implementations so they're ready for the next test.
      *
-     * @param stubs A list of all the {{@link WireMockStub} instances that are available.
+     * @param stubs A list of all the {@link WireMockStub} instances that are available.
      *
      * @throws Exception If something goes wrong during the resetting. This will bubble up and get caught by JUnit,
      * which will stop the test.


### PR DESCRIPTION
Removed an extra curly brace in JavaDoc.

This fixes #20.