### PR TITLE
Share Wiremock server instance across test classes instead of shutting it down

### DIFF
--- a/src/test/java/com/thomaskasene/wiremock/junit/WireMockStubsTest.java
+++ b/src/test/java/com/thomaskasene/wiremock/junit/WireMockStubsTest.java
@@ -4,24 +4,11 @@ import com.github.tomakehurst.wiremock.client.WireMock;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.net.ConnectException;
-
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static org.junit.jupiter.api.Assertions.*;
 
 @DisplayName("When @WireMockStubs")
 public class WireMockStubsTest {
-
-    @NestedTestClass
-    @DisplayName("is absent")
-    class WireMockStubsAnnotationAbsentTest {
-
-        @Test
-        @DisplayName("the WireMock server is unavailable")
-        void serverIsUnavailable() {
-            assertThrows(ConnectException.class, () -> WireMock.stubFor(get("/test")));
-        }
-    }
 
     @WireMockStubs
     @NestedTestClass


### PR DESCRIPTION
When a test class is finished, the previous behavior was to shut down the Wiremock instance. This caused issues for application contexts such as those of Spring, where the context itself is shared between tests and test classes to save time. The Spring context would keep its connections to the WireMock server running for as long as possible, but the tests would eventually fail at random when the application tried to use a connection that was no longer alive.

The suggested solution is to keep all (unique) WireMock configurations and servers running, and let them all live until the JVM shuts them down. That way, they may be re-used between test classes, and Spring (and other HTTP clients) hopefully won't struggle with flaky tests.

This fixes #24 